### PR TITLE
Read through all the available certificate endpoints

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   call-inclusive-naming-check:
     name: Inclusive naming
-    uses: canonical-web-and-design/Inclusive-naming/.github/workflows/woke.yaml@main
+    uses: canonical/inclusive-naming/.github/workflows/woke.yaml@main
     with:
       fail-on-error: "true"
 

--- a/ops/ops/interface_tls_certificates/requires.py
+++ b/ops/ops/interface_tls_certificates/requires.py
@@ -42,7 +42,10 @@ class CertificatesRequires(Object):
     @cached_property
     def _raw_data(self):
         if self.relation and self.relation.units:
-            return self.relation.data[list(self.relation.units)[0]]
+            data = {}
+            for unit in self.relation.units:
+                data.update(self.relation.data[unit])
+            return data
         return None
 
     @cached_property

--- a/ops/tests/unit/test_ops_requires.py
+++ b/ops/tests/unit/test_ops_requires.py
@@ -101,9 +101,10 @@ def test_server_certs(certificates_requirer, relation_data):
         CertificatesRequires, "relation", new_callable=mock.PropertyMock
     ) as mock_prop:
         relation = mock_prop.return_value
-        relation.units = ["remote/0", certificates_requirer.model.unit]
+        relation.units = ["remote/0", "remote/1", certificates_requirer.model.unit]
         relation.data = {
-            "remote/0": relation_data,
+            "remote/0": {},  # missing data in the first relation
+            "remote/1": relation_data,
             certificates_requirer.model.unit: {"common_name": "system:kube-apiserver"},
         }
 


### PR DESCRIPTION
### Overview
Addresses [LP#2077457](https://bugs.launchpad.net/keystone-k8s-auth-operator/+bug/2077457)

Read each units databag merged together from a relation endpoint rather than just the first

### Details
* when used with an HA certificate authority, we must read the relation data from each unit, and merge the certificate together to form a comprehensive view of the juju model
* Include a test where the first unit doesn't provide any relation data